### PR TITLE
[fix] 修复BashUtil中process未正确设置重定向的问题。

### DIFF
--- a/Packages/com.focus-creative-games.hybridclr_unity/Editor/Installer/BashUtil.cs
+++ b/Packages/com.focus-creative-games.hybridclr_unity/Editor/Installer/BashUtil.cs
@@ -36,6 +36,8 @@ namespace HybridCLR.Editor.Installer
                 p.StartInfo.FileName = program;
                 p.StartInfo.UseShellExecute = false;
                 p.StartInfo.CreateNoWindow = true;
+                p.StartInfo.RedirectStandardOutput = true;
+                p.StartInfo.RedirectStandardError = true;
                 string argsStr = string.Join(" ", args.Select(arg => "\"" + arg + "\""));
                 p.StartInfo.Arguments = argsStr;
                 UnityEngine.Debug.Log($"[BashUtil] run => {program} {argsStr}");


### PR DESCRIPTION
p.StartInfo.RedirectStandardOutput 不设置为true的话，下方string stdOut = p.StandardOutput.ReadToEnd();必定会引发异常。StandardError类似。