### PR TITLE
修复报错：BuildFailedException: Build path contains a project previously built with the "Create Visual Studio Solution"

### DIFF
--- a/Assets/Editor/HybridCLR/BuildPlayerCommand.cs
+++ b/Assets/Editor/HybridCLR/BuildPlayerCommand.cs
@@ -55,6 +55,9 @@ namespace HybridCLR.Editor
 
             string location = $"{outputPath}/HybridCLRTrial.exe";
 
+            string oldBuildLocation = EditorUserBuildSettings.GetBuildLocation(target);
+            EditorUserBuildSettings.SetBuildLocation(target, location);
+
             PrebuildCommand.GenerateAll();
             Debug.Log("====> Build App");
             BuildPlayerOptions buildPlayerOptions = new BuildPlayerOptions()
@@ -67,6 +70,9 @@ namespace HybridCLR.Editor
             };
 
             var report = BuildPipeline.BuildPlayer(buildPlayerOptions);
+
+            EditorUserBuildSettings.SetBuildLocation(target, oldBuildLocation);
+
             if (report.summary.result != UnityEditor.Build.Reporting.BuildResult.Succeeded)
             {
                 Debug.LogError("打包失败");


### PR DESCRIPTION
在Build Settings窗口打包时，Unity会记录输出路径（相当于调用了`EditorUserBuildSettings.SetBuildLocation`）。下次使用`BuildPipeline.BuildPlayer`打包时，Unity会用之前记录的路径检查其中打包的结果是否开启了"Create Visual Studio Solution"。正确的逻辑应该是让Unity检查本次打包的输出路径。